### PR TITLE
Catch OSError exception when accessing serial ports on OSX

### DIFF
--- a/Arduino/arduino.py
+++ b/Arduino/arduino.py
@@ -66,7 +66,7 @@ def find_port(baud, timeout):
         log.debug('Found {0}, testing...'.format(p))
         try:
             sr = serial.Serial(p, baud, timeout=timeout)
-        except serial.serialutil.SerialException as e:
+        except (serial.serialutil.SerialException, OSError) as e:
             log.debug(str(e))
             continue
         time.sleep(2)


### PR DESCRIPTION
My OSX 10.9 install was generating an OSError("Resource busy") when checking each serial port in find_port() - it seems to generate this error when trying to access the Bluetooth-related serial ports. I added OSError to the catch statement to allow these ports to be skipped.
