### PR TITLE
FIX the license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='arduino-python',
       author='Tristan Hearn',
       author_email='tristanhearn@gmail.com',
       url='https://github.com/thearn/Python-Arduino-Command-API',
-      license='Apache 2.0',
+      license='MIT',
       packages=['Arduino'],
       )


### PR DESCRIPTION
There is the  MIT license.txt file and setup.py sets a different one
